### PR TITLE
[BUGFIX] Permettre la déconnexion

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Users
+  class SessionsController < Devise::SessionsController
+    skip_before_action :create_encryption_password, :provide_encryption_password, only: [:destroy]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   end
 
   devise_for :users, skip: %i[users registrable password], controllers: {
+    sessions: 'users/sessions',
     omniauth_callbacks: 'users/omniauth_callbacks'
   }
 

--- a/test/controllers/users/sessions_controller_test.rb
+++ b/test/controllers/users/sessions_controller_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  test '#destroy: should sign_out user ' do
+    sign_in users(:two)
+    delete destroy_user_session_url
+    assert_redirected_to root_url
+  end
+end


### PR DESCRIPTION
## :unicorn: What does this PR do?
Lors de la mise en place des redirections (https://github.com/VincentHardouin/pix-360/pull/6)  pour vérifier qu'un utilisateur a bien un mot de passe permettant le chiffrement de ses données, nous n'avions pas accordé l'accès à la route permettant de se déconnecter.

En effet, la politique de redirection marche sous forme de "white-list", par défaut toutes les routes sont soumises aux vérifications via les `before_action` sauf celles où nous estimons que ce n'est pas utile. Dans ces cas là nous ajoutons des `skip_before_action`

## :robot: Solution
Dans notre cas, nous devons supprimer les `before_action` non nécessaire à l'accès à la page de déconnexion. 

## :rainbow: Notes
> _Add any additional information._

## :100: Testing
1. Se connecter avec le SSO 
2. Constater qu'il est possible de se déconnecter en cliquant sur le bouton, vérifier que nous arrivons bien sur la page `index` / de connexion.