### PR TITLE
[FEATURE] Pouvoir demander une évaluation.

### DIFF
--- a/app/assets/stylesheets/feedbacks.scss
+++ b/app/assets/stylesheets/feedbacks.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Feedbacks controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class FeedbacksController < ApplicationController
+  before_action :set_feedback, only: %i[show edit update destroy]
+
+  def index
+    @feedbacks = current_user.received_feedbacks
+  end
+
+  def show; end
+
+  def new
+    @feedback = Feedback.new
+  end
+
+  def edit; end
+
+  def create
+    @feedback = current_user.received_feedbacks.create_with_shared_key cookies[:encryption_password]
+
+    respond_to do |format|
+      if @feedback.save
+        format.html { redirect_to @feedback, notice: 'Feedback was successfully created.' }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def update
+    respond_to do |format|
+      if @feedback.update(feedback_params)
+        format.html { redirect_to @feedback, notice: 'Feedback was successfully updated.' }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def destroy
+    @feedback.destroy
+    respond_to do |format|
+      format.html { redirect_to feedbacks_url, notice: 'Feedback was successfully destroyed.' }
+    end
+  end
+
+  private
+
+  def set_feedback
+    @feedback = Feedback.find(params[:id])
+  end
+
+  def feedback_params
+    params.fetch(:feedback, {})
+  end
+end

--- a/app/helpers/feedbacks_helper.rb
+++ b/app/helpers/feedbacks_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module FeedbacksHelper
+end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Feedback < ApplicationRecord
+end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
 class Feedback < ApplicationRecord
+  belongs_to :giver, class_name: 'User', optional: true, foreign_key: 'respondent_id', inverse_of: :given_feedbacks
+  belongs_to :requester, class_name: 'User', inverse_of: :received_feedbacks
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
+require('aes_256_gcm_encryption')
+require('elliptic_curve')
+
 class Feedback < ApplicationRecord
   belongs_to :giver, class_name: 'User', optional: true, foreign_key: 'respondent_id', inverse_of: :given_feedbacks
   belongs_to :requester, class_name: 'User', inverse_of: :received_feedbacks
+
+  def self.create_with_shared_key(encryption_password)
+    f = Feedback.new
+    keys = EllipticCurve.new
+    shared_key = keys.shared_key(f.requester.public_key)
+    f.shared_key = Aes256GcmEncryption.encrypt(shared_key, encryption_password)
+    f.shared_key_hash = BCrypt::Password.create(shared_key)
+    f.save
+    f
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,15 @@ class User < ApplicationRecord
 
   devise :omniauthable, omniauth_providers: [:google_oauth2]
 
+  has_many :given_feedbacks, class_name: 'Feedback',
+                             foreign_key: 'respondent_id',
+                             dependent: :destroy,
+                             inverse_of: :giver
+  has_many :received_feedbacks, class_name: 'Feedback',
+                                foreign_key: 'requester_id',
+                                dependent: :destroy,
+                                inverse_of: :requester
+
   def self.from_google_oauth2(auth)
     where(google_id: auth.uid).first_or_create do |user|
       user.email = auth.info.email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require('aes_256_gcm_encryption')
+require('elliptic_curve')
 
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
@@ -28,9 +29,9 @@ class User < ApplicationRecord
   end
 
   def create_encryption_keys
-    keys = OpenSSL::PKey::EC.generate('secp521r1')
-    self.public_key = keys.public_key.to_bn.to_s
-    self.private_key = Aes256GcmEncryption.encrypt(keys.to_pem, password)
+    keys = EllipticCurve.new
+    self.public_key = keys.public_key
+    self.private_key = Aes256GcmEncryption.encrypt(keys.private_key, password)
     save
   end
 

--- a/app/views/feedbacks/_form.html.erb
+++ b/app/views/feedbacks/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with(model: feedback) do |form| %>
+  <% if feedback.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(feedback.errors.count, "error") %> prohibited this feedback from being saved:</h2>
+
+      <ul>
+        <% feedback.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/feedbacks/edit.html.erb
+++ b/app/views/feedbacks/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Feedback</h1>
+
+<%= render 'form', feedback: @feedback %>
+
+<%= link_to 'Show', @feedback %> |
+<%= link_to 'Back', feedbacks_path %>

--- a/app/views/feedbacks/index.html.erb
+++ b/app/views/feedbacks/index.html.erb
@@ -1,0 +1,25 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Feedbacks</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @feedbacks.each do |feedback| %>
+      <tr>
+        <td><%= link_to 'Show', feedback %></td>
+        <td><%= link_to 'Edit', edit_feedback_path(feedback) %></td>
+        <td><%= link_to 'Destroy', feedback, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Feedback', new_feedback_path %>

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Feedback</h1>
+
+<%= render 'form', feedback: @feedback %>
+
+<%= link_to 'Back', feedbacks_path %>

--- a/app/views/feedbacks/show.html.erb
+++ b/app/views/feedbacks/show.html.erb
@@ -1,0 +1,4 @@
+<p id="notice"><%= notice %></p>
+
+<%= link_to 'Edit', edit_feedback_path(@feedback) %> |
+<%= link_to 'Back', feedbacks_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  resources :feedbacks
   get 'encryption', to: 'encryption#index'
   patch 'encryption/save'
   get 'encryption/edit'

--- a/db/migrate/20220110131235_create_feedbacks.rb
+++ b/db/migrate/20220110131235_create_feedbacks.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateFeedbacks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :feedbacks do |t|
+      t.string :content
+      t.string :shared_key
+      t.string :shared_key_hash
+      t.integer :requester_id, null: false
+      t.integer :respondent_id
+
+      t.timestamps
+    end
+    add_foreign_key :feedbacks, :users, column: :requester_id
+    add_foreign_key :feedbacks, :users, column: :respondent_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_17_131703) do
+ActiveRecord::Schema.define(version: 2022_01_10_131235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "feedbacks", force: :cascade do |t|
+    t.string "content"
+    t.string "shared_key"
+    t.string "shared_key_hash"
+    t.integer "requester_id", null: false
+    t.integer "respondent_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -31,4 +41,6 @@ ActiveRecord::Schema.define(version: 2021_11_17_131703) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "feedbacks", "users", column: "requester_id"
+  add_foreign_key "feedbacks", "users", column: "respondent_id"
 end

--- a/lib/elliptic_curve.rb
+++ b/lib/elliptic_curve.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require('openssl')
+
+class EllipticCurve
+  METHOD = 'secp521r1'
+
+  def initialize
+    @keys = OpenSSL::PKey::EC.generate(METHOD)
+  end
+
+  def shared_key(public_key_string)
+    group = OpenSSL::PKey::EC::Group.new(METHOD)
+    public_key_point = OpenSSL::PKey::EC::Point.new(group, OpenSSL::BN.new(public_key_string))
+    @keys.dh_compute_key(public_key_point)
+  end
+end

--- a/lib/elliptic_curve.rb
+++ b/lib/elliptic_curve.rb
@@ -14,4 +14,12 @@ class EllipticCurve
     public_key_point = OpenSSL::PKey::EC::Point.new(group, OpenSSL::BN.new(public_key_string))
     @keys.dh_compute_key(public_key_point)
   end
+
+  def public_key
+    @keys.public_key.to_bn.to_s
+  end
+
+  def private_key
+    @keys.to_pem
+  end
 end

--- a/test/controllers/feedbacks_controller_test.rb
+++ b/test/controllers/feedbacks_controller_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class FeedbacksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:two)
+    sign_in @user
+    @user.password = '123456'
+    @user.create_encryption_keys
+    patch encryption_save_url,
+          params: { user: { password: '123456' } }
+  end
+
+  class Index < FeedbacksControllerTest
+    test 'should get index' do
+      get feedbacks_url
+      assert_response :success
+    end
+  end
+
+  class Create < FeedbacksControllerTest
+    test 'should create feedback with shared_key' do
+      post feedbacks_url,
+           params: { feedback: {} }
+
+      assert_response :redirect
+      assert_not_empty @user.received_feedbacks
+      assert_not_empty @user.received_feedbacks[0].shared_key
+    end
+  end
+end

--- a/test/fixtures/feedbacks.yml
+++ b/test/fixtures/feedbacks.yml
@@ -1,0 +1,6 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#

--- a/test/models/feedback_test.rb
+++ b/test/models/feedback_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class FeedbackTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/feedback_test.rb
+++ b/test/models/feedback_test.rb
@@ -3,7 +3,20 @@
 require 'test_helper'
 
 class FeedbackTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  class CreateWithSharedKey < FeedbackTest
+    setup do
+      @user = users(:two)
+      @user.password = 'azerty123'
+      @user.create_encryption_keys
+    end
+
+    test 'should create feedback from user and create shared_key' do
+      feedback = @user.received_feedbacks.create_with_shared_key 'toto123'
+      assert_not_empty feedback.shared_key
+      assert_not_empty feedback.shared_key_hash
+
+      decrypted_shared_key = Aes256GcmEncryption.decrypt(feedback.shared_key, 'toto123')
+      assert BCrypt::Password.new(feedback.shared_key_hash) == decrypted_shared_key
+    end
+  end
 end


### PR DESCRIPTION
## :unicorn: What does this PR do?
Actuellement, il n'est pas possible pour une personne de demander une évaluation. 

## :robot: Solution
Ajout d'un model `Feedback`, qui contient : `requester_id`, `respondent_id`, `content`, `shared_key` et `shared_key_hash`.

La `shared_key` offre la possibilité à une personne extérieur de pouvoir remplir le formulaire. Celle-ci ne doit donc pas être partagé à n'importe qui.   
Elle est chiffrée par le mot de passe du `requester_id` pour son stockage. Elle est envoyée en claire à l'évaluateur.  

Le `shared_key_hash` permettra de vérifier que l'utilisateur dispose de la bonne `sharedKey` sans que nous en connaissions la valeur. 

## :rainbow: Notes
- Une class `EllipticCurve` a émergé du design, elle permet de simplifier la compréhension du domaine. 

## :100: Testing
https://pfe-pix-360-pr18.osc-fr1.scalingo.io/
- Se rendre sur l'url `/feedbacks`
- Cliquer sur `New feedbacks`
- Et vérifier le bon fonctionnement