### PR TITLE
[FEATURE] Génération du lien de partage d'un feedback

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -2,6 +2,7 @@
 
 class FeedbacksController < ApplicationController
   before_action :set_feedback, only: %i[show edit update destroy]
+  helper_method :edit_feedback_link
 
   def index
     @feedbacks = current_user.received_feedbacks
@@ -52,5 +53,10 @@ class FeedbacksController < ApplicationController
 
   def feedback_params
     params.fetch(:feedback, {})
+  end
+
+  def edit_feedback_link(feedback)
+    shared_key = feedback.decrypted_shared_key cookies[:encryption_password]
+    edit_feedback_url(id: feedback.id, shared_key: shared_key)
   end
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -2,6 +2,7 @@
 
 require('aes_256_gcm_encryption')
 require('elliptic_curve')
+require('bcrypt')
 
 class Feedback < ApplicationRecord
   belongs_to :giver, class_name: 'User', optional: true, foreign_key: 'respondent_id', inverse_of: :given_feedbacks
@@ -15,5 +16,9 @@ class Feedback < ApplicationRecord
     f.shared_key_hash = BCrypt::Password.create(shared_key)
     f.save
     f
+  end
+
+  def decrypted_shared_key(encryption_password)
+    Aes256GcmEncryption.decrypt(shared_key, encryption_password)
   end
 end

--- a/app/views/feedbacks/show.html.erb
+++ b/app/views/feedbacks/show.html.erb
@@ -1,4 +1,7 @@
 <p id="notice"><%= notice %></p>
 
+<p>Lien de partage :</p>
+<p><%= edit_feedback_link @feedback %></p>
+
 <%= link_to 'Edit', edit_feedback_path(@feedback) %> |
 <%= link_to 'Back', feedbacks_path %>

--- a/lib/elliptic_curve.rb
+++ b/lib/elliptic_curve.rb
@@ -12,7 +12,7 @@ class EllipticCurve
   def shared_key(public_key_string)
     group = OpenSSL::PKey::EC::Group.new(METHOD)
     public_key_point = OpenSSL::PKey::EC::Point.new(group, OpenSSL::BN.new(public_key_string))
-    @keys.dh_compute_key(public_key_point)
+    Base64.encode64 @keys.dh_compute_key(public_key_point)
   end
 
   def public_key


### PR DESCRIPTION
## :unicorn: What does this PR do?
On veut générer un lien afin qu'un utilisateur puisse partager son feedback

## :robot: Solution
Le lien est créer lors de l'affichage du feedback. L'URL contient le paramètre `?sharedKey=` contenant le clé de partage préalablement déchiffrée.

## :rainbow: Notes
Modification de la génération de la sharedKey afin qu'elle soit lisible.

## :100: Testing
- reset la bdd
- lancer l'appli
- créer un feedback
- vérifier que le lien s'affiche de manière lisible
