### PR TITLE
[FEATURE] Ajout d'un nom pour l'adresse e-mail

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: email_address_with_name('notification@pix.fr', 'Pix 360')
   layout 'mailer'
 end

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class FeedbackMailer < ApplicationMailer
-  default from: 'feedbacks@example.com'
+  default from: email_address_with_name('notification@pix.fr', 'Pix 360')
 
   def feedback_email
     @email = params[:email]


### PR DESCRIPTION
## :unicorn: What does this PR do?
Lors de l'envoie d'un e-mail, uniquement l'adresse e-mail est affichée, ce qui n'est pas très esthétique.

## :robot: Solution
Ajouter un nom pour l'adresse e-mail

## :rainbow: Notes
> _Add any additional information._

## :100: Testing
> _Describe how to test._
