### PR TITLE
[BUGFIX] Correction du problème de taille des champs dans le formulaire de création de mot de passe.

### DIFF
--- a/app/assets/stylesheets/encryption.scss
+++ b/app/assets/stylesheets/encryption.scss
@@ -184,5 +184,6 @@
     padding: 0 10px;
     border-radius: 3px;
     border: 2px solid #DFE1E6;
+    width: 100%;
   }
 }

--- a/app/assets/stylesheets/encryption.scss
+++ b/app/assets/stylesheets/encryption.scss
@@ -185,5 +185,6 @@
     border-radius: 3px;
     border: 2px solid #DFE1E6;
     width: 100%;
+    box-sizing: border-box;
   }
 }

--- a/app/views/encryption/edit.html.erb
+++ b/app/views/encryption/edit.html.erb
@@ -13,11 +13,11 @@
       <%= f.hidden_field :must_change_password, value: false %>
 
       <% if f.object.errors.any? %>
-        <div class="alert alert-danger">
-          <% f.object.errors.full_messages.each do |message| %>
+        <% f.object.errors.full_messages.each do |message| %>
+          <div class="flash flash__error" >
             <div><%= message %></div>
-          <% end %>
-        </div>
+          </div>
+        <% end %>
       <% end %>
 
       <div class="encryption-body__field">


### PR DESCRIPTION
## :unicorn: What does this PR do?
Lorsqu'il y a une erreur sur les champs mot de passe, ces derniers ne prennent plus tout l'espace qui leur sont alloués. 

## :robot: Solution
Fixer l'espace alloué aux champs de mot de passe. 

## :rainbow: Notes
Au passage les erreurs flash ont été stylisé. 

## :100: Testing
> _Describe how to test._
