### PR TITLE
[BUGFIX] Pouvoir se connecter quand l'utilisateur arrive directement sur la page `/users/sign_in`.

### DIFF
--- a/app/controllers/encryption_controller.rb
+++ b/app/controllers/encryption_controller.rb
@@ -8,8 +8,9 @@ class EncryptionController < ApplicationController
   def index; end
 
   def save
-    if current_user.valid_password?(password_params)
-      cookies.encrypted[:encryption_password] = password_params
+    password = params[:user][:password]
+    if current_user.valid_password?(password)
+      cookies.encrypted[:encryption_password] = password
       redirect_back_or_default root_url
     else
       flash[:alert] = 'Le mot de passe saisie ne correspond pas.'
@@ -23,7 +24,7 @@ class EncryptionController < ApplicationController
 
   def update
     @user = current_user
-    if @user.update(password_params_from_edit)
+    if @user.update(encryption_params)
       @user.create_encryption_keys
       cookies.encrypted[:encryption_password] = params[:user][:password]
       bypass_sign_in @user, scope: :user
@@ -36,13 +37,8 @@ class EncryptionController < ApplicationController
 
   private
 
-  def password_params_from_edit
+  def encryption_params
     params.require(:user).permit(:password, :password_confirmation, :must_change_password)
-  end
-
-  def password_params
-    params.require(:user).permit(:password)
-    params[:user][:password]
   end
 
   def encryption_already_set

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -15,7 +15,7 @@ module Users
     end
 
     def after_sign_in_path_for(resource_or_scope)
-      session[:return_to] || stored_location_for(resource_or_scope)
+      session[:return_to] || stored_location_for(resource_or_scope) || root_path
     end
   end
 end


### PR DESCRIPTION
## :unicorn: What does this PR do?
Lorsque l'utilisateur arrive directement sur la page `/users/sign_in`, il ne peut pas se connecter car il n'existe pas de redirection. 

## :robot: Solution
Ajouter une redirection par défaut pour ce cas.

## :rainbow: Notes
> _Add any additional information._

## :100: Testing
- Aller sur la page `/users/sign_in` 
- Reload la page
- Se connecter
- Constater qu'on est bien redirigé sur la page d'accueil.