### PR TITLE
[FEATURE] Proposer à l'utilisateur d'enregistrer ou d'envoyer son évaluation.

### DIFF
--- a/app/assets/stylesheets/feedbacks.scss
+++ b/app/assets/stylesheets/feedbacks.scss
@@ -3,7 +3,7 @@
 // You can use Sass (SCSS) here: https://sass-lang.com/
 @import "globals";
 
-.edit-feedback {
+.feedbacks {
   &__page {
     width: 95%;
     margin: 0 auto;
@@ -33,9 +33,13 @@
       font-size: 2.25rem;
     }
   }
-}
 
-.feedbacks {
+  &__content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
   &__form {
     display: flex;
     flex-direction: column;
@@ -54,6 +58,13 @@
 
   &__button {
     margin-top: 32px;
+  }
+
+  &__actions {
+    margin-top: 32px;
+    display: flex;
+    flex-direction: row;
+    gap: 14px;
   }
 }
 
@@ -99,35 +110,6 @@
 }
 
 .show-feedback {
-  &__page {
-    width: 95%;
-    margin: 0 auto;
-    padding: 20px 10px;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-around;
-    align-items: center;
-
-    @include device-is('tablet') {
-      width: 820px;
-      margin: 20px auto;
-      padding: 40px 80px;
-    }
-  }
-
-  &__title {
-    font-family: $font-open-sans;
-    font-weight: $font-light;
-    font-size: 1.563rem;
-    color: $grey-80;
-    margin-top: 0;
-    margin-bottom: 32px;
-    text-align: center;
-
-    @include device-is('desktop') {
-      font-size: 2.25rem;
-    }
-  }
 
   &__field {
     width: 100%;
@@ -139,12 +121,6 @@
     margin-bottom: 56px;
     display: flex;
     justify-content: center;
-  }
-
-  &__actions {
-    display: flex;
-    flex-direction: row;
-    gap: 14px;
   }
 }
 
@@ -171,36 +147,6 @@
 }
 
 .index-feedback {
-  &__page {
-    width: 95%;
-    margin: 0 auto;
-    padding: 20px 10px;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-around;
-    align-items: center;
-
-    @include device-is('desktop') {
-      width: 820px;
-      margin: 20px auto;
-      padding: 40px 80px;
-    }
-  }
-
-  &__title {
-    font-family: $font-open-sans;
-    font-weight: $font-light;
-    font-size: 1.563rem;
-    color: $grey-80;
-    margin-top: 0;
-    margin-bottom: 32px;
-    text-align: center;
-
-    @include device-is('desktop') {
-      font-size: 2.25rem;
-    }
-  }
-
   &__row {
     display: flex;
     flex-direction: column;
@@ -263,14 +209,6 @@
   &__date {
     font-weight: $font-light;
     font-size: .85rem;
-  }
-}
-
-.feedbacks {
-  &__content {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
   }
 }
 

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -135,10 +135,20 @@ class FeedbacksController < ApplicationController
   def update_content(is_submitted, success_message, error_message)
     respondent_id = current_user ? current_user.id : nil
     if @feedback.update_content(feedback_params, respondent_id, is_submitted: is_submitted)
-      redirect_to @feedback, flash: { success: success_message }
+      flash[:success] = success_message
+      redirect_after_update
     else
       flash[:error] = error_message
       render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def redirect_after_update
+    if user_signed_in?
+      redirect_to feedbacks_path
+    else
+      shared_key = params[:feedback][:decrypted_shared_key]
+      redirect_to edit_feedback_path(id: @feedback.id, shared_key: shared_key, external_user: true)
     end
   end
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -36,11 +36,12 @@ class Feedback < ApplicationRecord
     self.decrypted_shared_key = Aes256GcmEncryption.decrypt(shared_key, encryption_password)
   end
 
-  def update_content(feedback_params, respondent_id = nil)
+  def update_content(feedback_params, respondent_id = nil, is_submitted: false)
     self.content = Aes256GcmEncryption.encrypt(feedback_params[:content].to_json,
                                                feedback_params[:decrypted_shared_key])
     self.respondent_id = respondent_id
     self.is_filled = true
+    self.is_submitted = is_submitted
     save
   end
 

--- a/app/views/feedbacks/_content.html.erb
+++ b/app/views/feedbacks/_content.html.erb
@@ -1,0 +1,20 @@
+<div class="show-feedback__field">
+  <div class="show-feedback-field__label">Points positifs</div>
+  <div class="show-feedback-field__input">
+    <%= sanitize markdown(@feedback.decrypted_content[:positive_points]) %>
+  </div>
+</div>
+
+<div class="show-feedback__field">
+  <div class="show-feedback-field__label">Axes d'amélioration</div>
+  <div class="show-feedback-field__input">
+    <%= sanitize markdown(@feedback.decrypted_content[:improvements_areas]) %>
+  </div>
+</div>
+
+<div class="show-feedback__field">
+  <div class="show-feedback-field__label">Commentaires</div>
+  <div class="show-feedback-field__input">
+    <%= sanitize markdown(@feedback.decrypted_content[:comments]) %>
+  </div>
+</div>

--- a/app/views/feedbacks/edit.html.erb
+++ b/app/views/feedbacks/edit.html.erb
@@ -1,6 +1,5 @@
-<main class="edit-feedback__page">
-  <h1 class="edit-feedback__title">Modification de l'évaluation</h1>
-
+<main class="feedbacks__page">
+  <h1 class="feedbacks__title">Modification de l'évaluation</h1>
   <%= form_with model: @feedback, class: 'feedbacks__form' do |form| %>
     <% if @feedback.errors.any? %>
       <div id="error_explanation">

--- a/app/views/feedbacks/edit.html.erb
+++ b/app/views/feedbacks/edit.html.erb
@@ -5,40 +5,50 @@
       Pour : <%= @feedback.requester.full_name %>
     </div>
   </div>
-  <%= form_with model: @feedback, class: 'feedbacks__form' do |form| %>
-    <% if @feedback.errors.any? %>
-      <div id="error_explanation">
-        <h2><%= pluralize(@feedback.errors.count, "error") %> prohibited this feedback from being saved:</h2>
 
-        <ul>
-          <% @feedback.errors.each do |error| %>
-            <li><%= error.full_message %></li>
-          <% end %>
-        </ul>
+  <% if @feedback.is_submitted %>
+    <%= render "content" %>
+
+    <% if user_signed_in? %>
+      <div class="feedbacks__actions">
+        <%= link_to 'Retour aux évaluations', feedbacks_path, class: 'pix-button pix-button--shape-rounded pix-button--size-big pix-button--background-transparent-light pix-button--border' %>
       </div>
     <% end %>
+  <% else %>
+    <%= form_with model: @feedback, class: 'feedbacks__form' do |form| %>
+      <% if @feedback.errors.any? %>
+        <div id="error_explanation">
+          <h2><%= pluralize(@feedback.errors.count, "error") %> prohibited this feedback from being saved:</h2>
 
-    <%= form.hidden_field :decrypted_shared_key %>
+          <ul>
+            <% @feedback.errors.each do |error| %>
+              <li><%= error.full_message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
 
-    <div class="feedbacks__field">
-      <label for="feedbacks_content_positive_points" class="feedbacks-field__label">Points positifs</label>
-      <textarea id="feedbacks_content_positive_points"  class="feedbacks-field__input" name="feedback[content][positive_points]"><%= @feedback.decrypted_content[:positive_points] %></textarea>
-    </div>
+      <%= form.hidden_field :decrypted_shared_key %>
 
-    <div class="feedbacks__field">
-      <label for="feedbacks_content_improvements_areas" class="feedbacks-field__label">Axes d'amélioration</label>
-      <textarea id="feedbacks_content_improvements_areas"  class="feedbacks-field__input" name="feedback[content][improvements_areas]"><%= @feedback.decrypted_content[:improvements_areas]%></textarea>
-    </div>
+      <div class="feedbacks__field">
+        <label for="feedbacks_content_positive_points" class="feedbacks-field__label">Points positifs</label>
+        <textarea id="feedbacks_content_positive_points"  class="feedbacks-field__input" name="feedback[content][positive_points]"><%= @feedback.decrypted_content[:positive_points] %></textarea>
+      </div>
 
-    <div class="feedbacks__field">
-      <label for="feedbacks_content_comments" class="feedbacks-field__label">Commentaires</label>
-      <textarea id="feedbacks_content_comments"  class="feedbacks-field__input" name="feedback[content][comments]"><%= @feedback.decrypted_content[:comments]%></textarea>
-    </div>
+      <div class="feedbacks__field">
+        <label for="feedbacks_content_improvements_areas" class="feedbacks-field__label">Axes d'amélioration</label>
+        <textarea id="feedbacks_content_improvements_areas"  class="feedbacks-field__input" name="feedback[content][improvements_areas]"><%= @feedback.decrypted_content[:improvements_areas]%></textarea>
+      </div>
 
-    <div class="feedbacks__actions">
-      <%= form.button "Enregistrer", class: 'pix-button pix-button--shape-rounded pix-button--size-big pix-button--background-transparent-light pix-button--border' %>
-      <%= form.button "Enregistrer et envoyer", name: 'submit', data: { confirm: "Êtes-vous certains d'envoyer l'évaluation ? Vous ne pourrez plus la modifier." }, class: 'pix-button pix-button--shape-rounded pix-button--size-big pix-button--background-blue' %>
-    </div>
+      <div class="feedbacks__field">
+        <label for="feedbacks_content_comments" class="feedbacks-field__label">Commentaires</label>
+        <textarea id="feedbacks_content_comments"  class="feedbacks-field__input" name="feedback[content][comments]"><%= @feedback.decrypted_content[:comments]%></textarea>
+      </div>
+
+      <div class="feedbacks__actions">
+        <%= form.button "Enregistrer", class: 'pix-button pix-button--shape-rounded pix-button--size-big pix-button--background-transparent-light pix-button--border' %>
+        <%= form.button "Enregistrer et envoyer", name: 'submit', data: { confirm: "Êtes-vous certains d'envoyer l'évaluation ? Vous ne pourrez plus la modifier." }, class: 'pix-button pix-button--shape-rounded pix-button--size-big pix-button--background-blue' %>
+      </div>
+    <% end %>
   <% end %>
-
 </main>

--- a/app/views/feedbacks/edit.html.erb
+++ b/app/views/feedbacks/edit.html.erb
@@ -1,5 +1,10 @@
 <main class="feedbacks__page">
   <h1 class="feedbacks__title">Modification de l'évaluation</h1>
+  <div class="feedbacks__content">
+    <div class="feedbacks-content__information">
+      Pour : <%= @feedback.requester.full_name %>
+    </div>
+  </div>
   <%= form_with model: @feedback, class: 'feedbacks__form' do |form| %>
     <% if @feedback.errors.any? %>
       <div id="error_explanation">
@@ -30,8 +35,9 @@
       <textarea id="feedbacks_content_comments"  class="feedbacks-field__input" name="feedback[content][comments]"><%= @feedback.decrypted_content[:comments]%></textarea>
     </div>
 
-    <div class="feedbacks__button">
-      <%= form.submit "Enregistrer l'évaluation", class: 'pix-button pix-button--shape-rounded pix-button--size-big pix-button--background-blue' %>
+    <div class="feedbacks__actions">
+      <%= form.button "Enregistrer", class: 'pix-button pix-button--shape-rounded pix-button--size-big pix-button--background-transparent-light pix-button--border' %>
+      <%= form.button "Enregistrer et envoyer", name: 'submit', data: { confirm: "Êtes-vous certains d'envoyer l'évaluation ? Vous ne pourrez plus la modifier." }, class: 'pix-button pix-button--shape-rounded pix-button--size-big pix-button--background-blue' %>
     </div>
   <% end %>
 

--- a/app/views/feedbacks/given.html.erb
+++ b/app/views/feedbacks/given.html.erb
@@ -1,5 +1,5 @@
-<main class="index-feedback__page">
-  <h1 class="index-feedback__title">Évaluations données</h1>
+<main class="feedbacks__page">
+  <h1 class="feedbacks__title">Évaluations données</h1>
 
   <% if @feedbacks.present? %>
     <div class="index-feedback__row">

--- a/app/views/feedbacks/index.html.erb
+++ b/app/views/feedbacks/index.html.erb
@@ -8,7 +8,7 @@
         <%= link_to feedback, class: 'feedback' do %>
           <div class="feedback__information">
             <div class="feedback-information__respondent">
-              <% if feedback.is_filled %>
+              <% if feedback.is_submitted %>
                 <% if feedback.giver %>
                   <%= "Remplie par #{feedback.giver.full_name}" %>
                 <% else %>

--- a/app/views/feedbacks/index.html.erb
+++ b/app/views/feedbacks/index.html.erb
@@ -1,5 +1,5 @@
-<main class="index-feedback__page">
-  <h1 class="index-feedback__title">Évaluations reçues</h1>
+<main class="feedbacks__page">
+  <h1 class="feedbacks__title">Évaluations reçues</h1>
   <% if @feedbacks.present? %>
     <%= link_to 'Demander une évaluation', new_feedback_path, class: 'pix-button pix-button--shape-rounded pix-button--size-big pix-button--background-blue' %>
     <div class="index-feedback__row">

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -1,5 +1,5 @@
-<main class="edit-feedback__page">
-  <h1 class="edit-feedback__title">Nouvelle évaluation</h1>
+<main class="feedbacks__page">
+  <h1 class="feedbacks__title">Nouvelle évaluation</h1>
 
   <%= form_with model: @feedback, class: 'feedbacks__form' do |form| %>
     <% if @feedback.errors.any? %>

--- a/app/views/feedbacks/show.html.erb
+++ b/app/views/feedbacks/show.html.erb
@@ -1,6 +1,6 @@
 <%= javascript_pack_tag 'clipboard' %>
-<main class="show-feedback__page">
-  <h1 class="show-feedback__title">Évaluation</h1>
+<main class="feedbacks__page">
+  <h1 class="feedbacks__title">Évaluation</h1>
 
   <div class="show-feedback__link">
     <button class="show-feedback--link pix-button pix-button--background-blue pix-button--size-big pix-button--shape-rounded" data-clipboard-text="<%= edit_feedback_link @feedback %>">
@@ -30,7 +30,7 @@
     </div>
   </div>
 
-  <div class="show-feedback__actions">
+  <div class="feedbacks__actions">
     <%= link_to 'Retour aux évaluations', feedbacks_path, class: 'pix-button pix-button--shape-rounded pix-button--size-big pix-button--background-transparent-light pix-button--border' %>
     <%= link_to 'Supprimer', @feedback, method: :delete, data: { confirm: 'Êtes-vous sûr ?'}, class: 'pix-button pix-button--shape-rounded pix-button--size-big pix-button--background-red' %>
   </div>

--- a/app/views/feedbacks/show.html.erb
+++ b/app/views/feedbacks/show.html.erb
@@ -10,26 +10,7 @@
   </div>
 
   <% if @feedback.is_submitted %>
-    <div class="show-feedback__field">
-      <div class="show-feedback-field__label">Points positifs</div>
-      <div class="show-feedback-field__input">
-        <%= sanitize markdown(@feedback.decrypted_content[:positive_points]) %>
-      </div>
-    </div>
-
-    <div class="show-feedback__field">
-      <div class="show-feedback-field__label">Axes d'amélioration</div>
-      <div class="show-feedback-field__input">
-        <%= sanitize markdown(@feedback.decrypted_content[:improvements_areas]) %>
-      </div>
-    </div>
-
-    <div class="show-feedback__field">
-      <div class="show-feedback-field__label">Commentaires</div>
-      <div class="show-feedback-field__input">
-        <%= sanitize markdown(@feedback.decrypted_content[:comments]) %>
-      </div>
-    </div>
+    <%= render "content" %>
   <% else %>
     <div class="feedbacks-content">
       <div class="feedbacks-content__information">

--- a/app/views/feedbacks/show.html.erb
+++ b/app/views/feedbacks/show.html.erb
@@ -9,26 +9,34 @@
     </button>
   </div>
 
-  <div class="show-feedback__field">
-    <div class="show-feedback-field__label">Points positifs</div>
-    <div class="show-feedback-field__input">
-      <%= sanitize markdown(@feedback.decrypted_content[:positive_points]) %>
+  <% if @feedback.is_submitted %>
+    <div class="show-feedback__field">
+      <div class="show-feedback-field__label">Points positifs</div>
+      <div class="show-feedback-field__input">
+        <%= sanitize markdown(@feedback.decrypted_content[:positive_points]) %>
+      </div>
     </div>
-  </div>
 
-  <div class="show-feedback__field">
-    <div class="show-feedback-field__label">Axes d'amélioration</div>
-    <div class="show-feedback-field__input">
-      <%= sanitize markdown(@feedback.decrypted_content[:improvements_areas]) %>
+    <div class="show-feedback__field">
+      <div class="show-feedback-field__label">Axes d'amélioration</div>
+      <div class="show-feedback-field__input">
+        <%= sanitize markdown(@feedback.decrypted_content[:improvements_areas]) %>
+      </div>
     </div>
-  </div>
 
-  <div class="show-feedback__field">
-    <div class="show-feedback-field__label">Commentaires</div>
-    <div class="show-feedback-field__input">
-      <%= sanitize markdown(@feedback.decrypted_content[:comments]) %>
+    <div class="show-feedback__field">
+      <div class="show-feedback-field__label">Commentaires</div>
+      <div class="show-feedback-field__input">
+        <%= sanitize markdown(@feedback.decrypted_content[:comments]) %>
+      </div>
     </div>
-  </div>
+  <% else %>
+    <div class="feedbacks-content">
+      <div class="feedbacks-content__information">
+        L'évaluation n'a pas encore reçu de réponse.
+      </div>
+    </div>
+  <% end %>
 
   <div class="feedbacks__actions">
     <%= link_to 'Retour aux évaluations', feedbacks_path, class: 'pix-button pix-button--shape-rounded pix-button--size-big pix-button--background-transparent-light pix-button--border' %>

--- a/db/migrate/20220122150010_add_is_submitted_to_feedbacks.rb
+++ b/db/migrate/20220122150010_add_is_submitted_to_feedbacks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIsSubmittedToFeedbacks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :feedbacks, :is_submitted, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_20_092459) do
+ActiveRecord::Schema.define(version: 2022_01_22_150010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2022_01_20_092459) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "is_filled", default: false, null: false
+    t.boolean "is_submitted", default: false, null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/controllers/feedbacks_controller_test.rb
+++ b/test/controllers/feedbacks_controller_test.rb
@@ -44,6 +44,7 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
           get edit_feedback_url(id: 55_665)
 
           assert_response :redirect
+          assert_equal "L'évaluation est introuvable.", flash[:error]
         end
       end
 
@@ -60,6 +61,7 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
 
               # then
               assert_response :redirect
+              assert_equal "Vous n'êtes pas autorisé à éditer cette évaluation.", flash[:error]
             end
 
             test 'should can edit when respondent is equal to current_user' do
@@ -83,6 +85,7 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
 
               # then
               assert_response :redirect
+              assert_equal "Vous n'êtes pas autorisé à éditer cette évaluation.", flash[:error]
             end
           end
         end
@@ -93,6 +96,7 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
             get edit_feedback_url(id: 1), params: { shared_key: 'bad_shared_key', external_user: 'true' }
 
             assert_response :redirect
+            assert_equal "Vous n'êtes pas autorisé à éditer cette évaluation.", flash[:error]
           end
 
           test 'should can edit feedback when shared_key is valid' do

--- a/test/controllers/feedbacks_controller_test.rb
+++ b/test/controllers/feedbacks_controller_test.rb
@@ -108,4 +108,53 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  class Update < FeedbacksControllerTest
+    test 'it should update feedback content' do
+      patch feedback_path(id: 1),
+            params: { feedback: { 'decrypted_shared_key': 'Azerty123*',
+                                  content: { 'positive_points' => 'foo', 'improvements_areas' => 'foo',
+                                             'comments' => 'foo' } } }
+
+      assert_response :redirect
+      assert_equal "L'évaluation a bien été modifiée.", flash[:success]
+
+      feedback = Feedback.find_by(id: 1)
+      assert_equal true, feedback.is_filled
+      assert_equal false, feedback.is_submitted
+    end
+
+    test 'it should update feedback content and submit it' do
+      patch feedback_path(id: 1),
+            params: { submit: '',
+                      feedback: { 'decrypted_shared_key': 'Azerty123*',
+                                  content: { 'positive_points' => 'foo', 'improvements_areas' => 'foo',
+                                             'comments' => 'foo' } } }
+
+      assert_response :redirect
+      assert_equal "L'évaluation a bien été envoyée.", flash[:success]
+
+      feedback = Feedback.find_by(id: 1)
+      assert_equal true, feedback.is_filled
+      assert_equal true, feedback.is_submitted
+    end
+
+    test 'it should not update feedback when feedback is already submitted' do
+      # given
+      feedback = Feedback.find_by(id: 1)
+      feedback.is_submitted = true
+      feedback.save
+
+      # when
+      patch feedback_path(id: 1),
+            params: { submit: '',
+                      feedback: { 'decrypted_shared_key': 'Azerty123*',
+                                  content: { 'positive_points' => 'foo', 'improvements_areas' => 'foo',
+                                             'comments' => 'foo' } } }
+
+      # then
+      assert_response :redirect
+      assert_equal 'Cette évaluation a déjà été soumise.', flash[:error]
+    end
+  end
 end


### PR DESCRIPTION
## :unicorn: What does this PR do?
Actuellement, l'évaluateur peut toujours revenir sur son évaluation et la modifier. Cela peut-être problématique en cas de conflits entre l'évaluateur et l'évalué.

## :robot: Solution
Proposer un système de enregistrement et un système d'envoie lorsqu'on a fini de faire son brouillon.
Lorsqu'on a alors envoyé son évaluation il est impossible de la modifier de nouveau

## :rainbow: Notes
> _Add any additional information._

## :100: Testing
- Se connecter et demande une évaluation

### Dans le rôle de l'évaluateur
- Je vais sur le lien
- Je remplie l'évaluation
- J'enregistre

### En tant qu'évalué
-  Je ne peux pas voir le contenu de l'évaluation 

### ETQ Évaluateur
- Je reviens sur le lien : => je constate que je peux toujours modifier
- Cette fois je modifie l'évaluation et j'envoie 
- Je ne peux plus modifier l'évaluation 

### En tant qu'évalué
-  Je peux à présent voir le contenu de l'évaluation 


