### PR TITLE
[FEATURE] Ajouter l'information de la prise en charge du markdown dans les champs de l'évaluation

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -58,3 +58,15 @@ body {
     color: $green-alert-dark;
   }
 }
+
+a {
+  color: $blue;
+
+  &:hover {
+    color: $blue-hover;
+  }
+
+  &:visited {
+    color: $blue;
+  }
+}

--- a/app/views/feedbacks/edit.html.erb
+++ b/app/views/feedbacks/edit.html.erb
@@ -47,6 +47,12 @@
 
       <%= form.hidden_field :decrypted_shared_key %>
 
+      <div class="feedbacks-content">
+        <div class="feedbacks-content__details">
+          Les champs de saisie de ce formulaire acceptent <a href="https://www.markdownguide.org/cheat-sheet/">le markdown</a>.
+        </div>
+      </div>
+
       <div class="feedbacks__field">
         <label for="feedbacks_content_positive_points" class="feedbacks-field__label">Points positifs</label>
         <textarea id="feedbacks_content_positive_points"  class="feedbacks-field__input" name="feedback[content][positive_points]"><%= @feedback.decrypted_content[:positive_points] %></textarea>


### PR DESCRIPTION
## :unicorn: What does this PR do?
Actuellement, l'utilisateur ne sait pas que les champs prennent en charge le markdown.

## :robot: Solution
Ajouter un texte explicatif avec une documentation

## :rainbow: Notes
> _Add any additional information._

## :100: Testing
> _Describe how to test._
