### PR TITLE
[BUGFIX] Supprimer le cookie contenant le mot de passe de chiffrement à la déconnexion.

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -5,6 +5,11 @@ module Users
     skip_before_action :create_encryption_password, :provide_encryption_password, only: %i[new destroy]
     helper_method :from_feedback?, :feedback_id, :shared_key
 
+    def destroy
+      cookies.delete(:encryption_password)
+      super
+    end
+
     private
 
     def from_feedback?


### PR DESCRIPTION
## :unicorn: What does this PR do?
Lorsque l'utilisateur a plusieurs comptes et qu'il se connecte avec un autre compte, le cookie contenant le mot de passe de chiffrement étant présent alors on ne lui demande pas son mot de passe de chiffrement. Cela engendre donc des problèmes pour déchiffrer les données.

## :robot: Solution
Supprimer le cookie au moment de la déconnexion

## :rainbow: Notes
> _Add any additional information._

## :100: Testing
> _Describe how to test._
